### PR TITLE
Fix #maven_program path

### DIFF
--- a/libraries/maven_installation_archive.rb
+++ b/libraries/maven_installation_archive.rb
@@ -81,7 +81,7 @@ module JavaServiceCookbook
       # @return [String]
       # @api private
       def maven_program
-        options.fetch(:maven_program, ::File.join(maven_home, new_resource.version, 'bin', 'mvn'))
+        options.fetch(:maven_program, ::File.join(maven_home, 'bin', 'mvn'))
       end
 
       # @return [String]


### PR DESCRIPTION
Provider was setting the wrong value for the path to maven by including
the version string twice. Thus the default recipe would fail b/c
`/opt/maven/3.3.9/3.3.9/bin/mvn` didn't exist.
